### PR TITLE
💚 Fix codecov upload

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -66,7 +66,7 @@ jobs:
         with:
           disable_search: true
           fail_ci_if_error: true
-          files: coverage/report/Cobertura.xml
+          files: coverage/*.cobertura.xml
           flags: unittests
           plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
Uses source cobertura files instead of consolidated in hopes of fixing Codecov upload issue.