### PR TITLE
🚚 Rearrange artifacts directory

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -42,7 +42,7 @@ jobs:
           -d:sonar.host.url='https://sonarcloud.io'
           -d:sonar.test.inclusions='**/*-test/**/*.cs,**/*.test.ts'
           -d:sonar.exclusions='**/*.json,**/*.props'
-          -d:sonar.coverageReportPaths='artifacts/test-results/report/SonarQube.xml'
+          -d:sonar.coverageReportPaths='artifacts/report/SonarQube.xml'
           -k:connorjs_dotnet-with-esproj-example -o:connorjs
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
@@ -61,22 +61,22 @@ jobs:
       - name: Fix JS package names
         shell: pwsh
         run: |
-          Get-ChildItem artifacts/test-results -Filter *.cobertura.xml -Name | Foreach-Object {
-            $projectName = $_ -replace ".{14}$"
-            (Get-Content artifacts/test-results/$_).replace("package name=`"main`"", "package name=`"${projectName}`"") | Set-Content artifacts/test-results/$_
+          Get-ChildItem artifacts -Recurse -Filter *.cobertura.xml -Name | Foreach-Object {
+            $projectName = ($_ -split "/")[0]
+            (Get-Content artifacts/$_).replace("package name=`"main`"", "package name=`"${projectName}`"") | Set-Content artifacts/$_
           }
 
       - name: ReportGenerator
         uses: danielpalme/ReportGenerator-GitHub-Action@5.3.8
         with:
-          reports: artifacts/test-results/*.cobertura.xml
-          targetdir: artifacts/test-results/report
+          reports: artifacts/*/test-results/*.cobertura.xml
+          targetdir: artifacts/report
           reporttypes: Cobertura;HtmlInline;JsonSummary;MarkdownSummaryGithub;SonarQube
 
       - name: Check coverage thresholds
         shell: pwsh
         run: |
-          $coverage = Get-Content -Raw artifacts/test-results/report/Summary.json | ConvertFrom-Json
+          $coverage = Get-Content -Raw artifacts/report/Summary.json | ConvertFrom-Json
           if ($coverage.summary.linecoverage -lt 80 -or $coverage.summary.branchcoverage -lt 80 -or $coverage.summary.methodcoverage -lt 80) {
             Write-Error "Coverage does not meet threshold.`n`nCI build failed."; Exit 1
           }
@@ -91,7 +91,7 @@ jobs:
 
       - name: Publish coverage in build summary
         if: always() # Still publish coverage if tests failed
-        run: cat artifacts/test-results/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
+        run: cat artifacts/report/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
 
       - name: Upload coverage report to Codecov
         if: always() # Still upload to CodeCov if tests failed
@@ -99,7 +99,7 @@ jobs:
         with:
           disable_search: true
           fail_ci_if_error: true
-          files: artifacts/test-results/*.cobertura.xml
+          files: artifacts/*/test-results/*.cobertura.xml
           flags: unittests
           plugins: noop
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/Directory.Solution.targets
+++ b/Directory.Solution.targets
@@ -20,6 +20,6 @@
 	<!-- Clean -->
 	<Target Name="Clean solution" AfterTargets="Clean">
 		<RemoveDir Directories="$(SolutionDir)artifacts" />
-		<RemoveDir Directories="$(PnpmInstallCheck)" />
+		<Delete Files="$(PnpmInstallCheck)" />
 	</Target>
 </Project>

--- a/Workspace.props
+++ b/Workspace.props
@@ -9,5 +9,6 @@
 		<ProjectRoot>$(MSBuildProjectDirectory)</ProjectRoot>
 		<ProjectRootRelative>$([MSBuild]::MakeRelative($(MSBuildThisFileDirectory), $(MSBuildProjectDirectory)))</ProjectRootRelative>
 		<ProjectName>$(MSBuildProjectName)</ProjectName>
+		<ProjectArtifacts>$(WorkspaceRoot)artifacts/$(ProjectName)/</ProjectArtifacts>
 	</PropertyGroup>
 </Project>

--- a/ci-build.ps1
+++ b/ci-build.ps1
@@ -14,20 +14,20 @@ function Write-Color($color) {
 }
 
 # Clean coverage directory
-Remove-Item -Recurse -Force artifacts/test-results -ErrorAction SilentlyContinue
+Remove-Item -Recurse -Force artifacts/*/test-results -ErrorAction SilentlyContinue
 
 # Run the build
 dotnet restore --verbosity $verbosity
 dotnet build --verbosity $verbosity --configuration Release --no-restore
 dotnet test --verbosity $verbosity --configuration Release --no-build
-Get-ChildItem artifacts/test-results -Filter *.cobertura.xml -Name | Foreach-Object {
-   $projectName = $_ -replace ".{14}$"
-	(Get-Content artifacts/test-results/$_).replace("package name=`"main`"", "package name=`"${projectName}`"") | Set-Content artifacts/test-results/$_
+Get-ChildItem artifacts -Recurse -Filter *.cobertura.xml -Name | Foreach-Object {
+   $projectName = ($_ -split "/")[0]
+	(Get-Content artifacts/$_).replace("package name=`"main`"", "package name=`"${projectName}`"") | Set-Content artifacts/$_
 }
-reportgenerator -reports:"artifacts/test-results/*.cobertura.xml" -targetdir:artifacts/test-results/report -reporttypes:"Cobertura;HtmlInline;JsonSummary;MarkdownSummaryGithub;SonarQube" -verbosity:Warning
+reportgenerator -reports:"artifacts/*/test-results/*.cobertura.xml" -targetdir:artifacts/report -reporttypes:"Cobertura;HtmlInline;JsonSummary;MarkdownSummaryGithub;SonarQube" -verbosity:Warning
 
 # Output coverage information
-$coverage = Get-Content -Raw artifacts/test-results/report/Summary.json | ConvertFrom-Json
+$coverage = Get-Content -Raw artifacts/report/Summary.json | ConvertFrom-Json
 $coverage.coverage.assemblies | Format-Table @{ L = ' Project '; E = { "$($_.name)" }; A = 'center' }, @{ L = ' Line '; E = { "$($_.coverage.toString() )%" }; A = 'center' }, @{ L = ' Branch '; E = { "$( $_.branchcoverage )%" }; A = 'center' }, @{ L = ' Method '; E = { "$( $_.methodcoverage )%" }; A = 'center' }
 if ($coverage.summary.linecoverage -lt 80 -or $coverage.summary.branchcoverage -lt 80 -or $coverage.summary.methodcoverage -lt 80) {
 	Write-Color red "Coverage does not meet threshold.`n`nCI build failed."; Exit 1

--- a/client/Directory.Build.props
+++ b/client/Directory.Build.props
@@ -3,8 +3,8 @@
 
 	<!-- .NET integration -->
 	<PropertyGroup>
-		<!-- Artifacts (needed different property for JSPS) -->
-		<BaseIntermediateOutputPath>$(WorkspaceRoot)artifacts/obj/$(MSBuildProjectName)/</BaseIntermediateOutputPath>
+		<!-- Artifacts -->
+		<BaseIntermediateOutputPath>$(ProjectArtifacts)obj/</BaseIntermediateOutputPath>
 
 		<!-- esproj still needs a target framework -->
 		<TargetFramework>net8.0</TargetFramework>

--- a/client/Directory.Build.targets
+++ b/client/Directory.Build.targets
@@ -19,7 +19,7 @@
 			StandardOutputImportance="normal"
 		/>
 		<!-- Print from tsc, similar to C# compile, for CLI consistency -->
-		<Message Text="$(ProjectName) -> $(WorkspaceRoot)artifacts/tsc/$(ProjectName)" Importance="high" />
+		<Message Text="$(ProjectName) -> $(WorkspaceRoot)artifacts/$(ProjectName)/tsc" Importance="high" />
 	</Target>
 
 	<!-- Build: eslint -->
@@ -33,7 +33,7 @@
 	<!-- Build: prettier -->
 	<Target Name="prettier" AfterTargets="Build">
 		<Exec
-			Command="pnpm exec prettier --ignore-unknown --cache-location $(WorkspaceRoot)artifacts/prettier $(PrettierArgs) ."
+			Command="pnpm exec prettier --ignore-unknown --cache --cache-location $(ProjectArtifacts)/prettier/cache.json $(PrettierArgs) ."
 			StandardOutputImportance="normal"
 		/>
 	</Target>
@@ -41,7 +41,7 @@
 	<!-- Test: vitest -->
 	<Target Name="vitest" AfterTargets="VSTest"
 			Inputs="$([MSBuild]::GetPathOfFileAbove('vitest.config.ts'));@(ProjectFiles)"
-			Outputs="$(WorkspaceRoot)artifacts/test-results/$(ProjectName).cobertura.xml"
+			Outputs="$(WorkspaceRoot)artifacts/$(ProjectName)/test-results"
 	>
 		<!-- Add output similar to .NET VSTest -->
 		<Message Text="Run tests: '$(ProjectRoot)' [vitest]" Importance="high" />

--- a/client/hello-js/tsconfig.json
+++ b/client/hello-js/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"baseUrl": ".",
-		"outDir": "../../artifacts/tsc/hello-js"
+		"outDir": "../../artifacts/hello-js/tsc"
 	},
 	"extends": "../tsconfig.json"
 }

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,12 +3,12 @@ import path from "node:path";
 import { defineConfig } from "vitest/config";
 
 const workspaceRoot = path.resolve(import.meta.dirname, `..`);
-const artifactsRoot = path.join(workspaceRoot, `artifacts`);
 const projectRoot = process.cwd();
 const projectName = path.basename(projectRoot);
+const projectArtifacts = path.join(workspaceRoot, `artifacts`, projectName);
 
 export default defineConfig({
-	cacheDir: path.join(artifactsRoot, `vite`, projectName),
+	cacheDir: path.join(projectArtifacts, `vite`),
 	test: {
 		coverage: {
 			all: true,
@@ -16,7 +16,7 @@ export default defineConfig({
 			provider: `v8`,
 			// Coverage reporter
 			reporter: [[`cobertura`, { file: `${projectName}.cobertura.xml` }]],
-			reportsDirectory: path.join(artifactsRoot, `test-results`),
+			reportsDirectory: path.join(projectArtifacts, `test-results`),
 			thresholds: {
 				branches: 80,
 				functions: 80,

--- a/server/Directory.Build.props
+++ b/server/Directory.Build.props
@@ -6,7 +6,8 @@
 		<IsTestProject>$(MSBuildProjectName.EndsWith('test'))</IsTestProject>
 
 		<!-- Artifacts -->
-		<ArtifactsPath>$(WorkspaceRoot)artifacts</ArtifactsPath>
+		<BaseIntermediateOutputPath>$(ProjectArtifacts)obj/</BaseIntermediateOutputPath>
+		<BaseOutputPath>$(ProjectArtifacts)bin/</BaseOutputPath>
 
 		<!-- Framework properties -->
 		<TargetFramework>net8.0</TargetFramework>
@@ -17,7 +18,7 @@
 
 	<PropertyGroup Condition="$(IsTestProject)">
 		<!-- Coverage arguments -->
-		<TestingPlatformCommandLineArguments>--coverage --coverage-output $(MSBuildProjectName).cobertura.xml --coverage-settings $(WorkspaceRoot)coverage.runsettings --results-directory $(WorkspaceRoot)artifacts/test-results</TestingPlatformCommandLineArguments>
+		<TestingPlatformCommandLineArguments>--coverage --coverage-output $(MSBuildProjectName).cobertura.xml --coverage-settings $(WorkspaceRoot)coverage.runsettings --results-directory $(ProjectArtifacts)test-results</TestingPlatformCommandLineArguments>
 	</PropertyGroup>
 
 	<ItemGroup Condition="$(IsTestProject)">


### PR DESCRIPTION
Inverts artifacts directory to have `project/type` organization instead of the previous `type/project`. This improves project-specific inspection and cleaning.